### PR TITLE
fixed text defaults

### DIFF
--- a/src/Component.props.js
+++ b/src/Component.props.js
@@ -8,14 +8,14 @@ const params = {
 
 // Specify PropTypes for non-Configurable Props
 const staticPropTypes = {
-  initialText: PropTypes.string,
+  text: PropTypes.string,
   logResults: PropTypes.func.isRequired,
   setNextEnabled: PropTypes.func.isRequired
 };
 
 // Specify Defaults for non-Configurable Props
 const staticDefaultProps = {
-  initialText: ""
+  text: ""
 };
 
 // Create merged propTypes, defaultProps

--- a/src/Component.stories.js
+++ b/src/Component.stories.js
@@ -94,6 +94,11 @@ const actions = {
 storiesOf("Component", module)
   .add("Default", () => (
     <Component
+      {...actions}
+    />
+  ))
+  .add("Initial Text", () => (
+    <Component
       text={text("Text", "Hello")}
       maxLength={number("Max Length", 50)}
       {...actions}


### PR DESCRIPTION
- `initialText` prop was renamed `text` to correctly reflect results model, but `defaultProps` was not updated.